### PR TITLE
Fix clone address in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,8 +55,8 @@ Getting started
 .. code-block:: bash
 
     # Get the code
-    git clone https://github.com/IATI/IATI-Stats.git
-    cd IATI-Stats
+    git clone https://github.com/devinit/gbm-IATI-Stats.git
+    cd gbm-IATI-Stats
 
     # Put some IATI data in the 'data' directory
     # (see previous section)


### PR DESCRIPTION
This repo is a fork of IATI/IATI-Stats, thererfore the code needs clone address needs to be rectified accordingly.